### PR TITLE
Reduced indentation in c# code 

### DIFF
--- a/src/Aggregator/AggregatorWorker.cs
+++ b/src/Aggregator/AggregatorWorker.cs
@@ -1,177 +1,176 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-namespace Metering.Aggregator
+namespace Metering.Aggregator;
+
+using System.Reactive.Linq;
+using System.Collections.Concurrent;
+using Metering.BaseTypes;
+using Metering.BaseTypes.EventHub;
+using Metering.Integration;
+using Metering.ClientSDK;
+using SomeMeterCollection = Microsoft.FSharp.Core.FSharpOption<Metering.BaseTypes.MeterCollection>;
+using Microsoft.FSharp.Core;
+using Metering.EventHub;
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Processor;
+
+// https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_ReadingEvents.md
+
+public class AggregatorWorker : BackgroundService
 {
-    using System.Reactive.Linq;
-    using System.Collections.Concurrent;
-    using Metering.BaseTypes;
-    using Metering.BaseTypes.EventHub;
-    using Metering.Integration;
-    using Metering.ClientSDK;
-    using SomeMeterCollection = Microsoft.FSharp.Core.FSharpOption<Metering.BaseTypes.MeterCollection>;
-    using Microsoft.FSharp.Core;
-    using Metering.EventHub;
-    using Azure.Messaging.EventHubs;
-    using Azure.Messaging.EventHubs.Processor;
+    private readonly ILogger<AggregatorWorker> _logger;
+    private readonly MeteringConfigurationProvider config;
 
-    // https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_ReadingEvents.md
-
-    public class AggregatorWorker : BackgroundService
+    public AggregatorWorker(ILogger<AggregatorWorker> logger, MeteringConfigurationProvider mcp)
     {
-        private readonly ILogger<AggregatorWorker> _logger;
-        private readonly MeteringConfigurationProvider config;
+        (_logger, config) = (logger, mcp);
+    }
 
-        public AggregatorWorker(ILogger<AggregatorWorker> logger, MeteringConfigurationProvider mcp)
-        {
-            (_logger, config) = (logger, mcp);
-        }
+    private IDisposable SubscribeEmitter(IObservable<MeterCollection> events)
+    {
+        List<MarketplaceRequest> previousToBeSubmitted = new();
+        ConcurrentQueue<MarketplaceRequest[]> tobeSubmitted = new();
+        var producer = config.MeteringConnections.createEventHubProducerClient();
 
-        private IDisposable SubscribeEmitter(IObservable<MeterCollection> events)
-        {
-            List<MarketplaceRequest> previousToBeSubmitted = new();
-            ConcurrentQueue<MarketplaceRequest[]> tobeSubmitted = new();
-            var producer = config.MeteringConnections.createEventHubProducerClient();
-
-            // Run an endless loop,
-            // - to look at the concurrent queue,
-            // - submit REST calls to marketplace, and then
-            // - submit the marketplace responses to EventHub. 
-            var task = Task.Factory.StartNew(async () => {
-                while (true)
+        // Run an endless loop,
+        // - to look at the concurrent queue,
+        // - submit REST calls to marketplace, and then
+        // - submit the marketplace responses to EventHub. 
+        var task = Task.Factory.StartNew(async () => {
+            while (true)
+            {
+                await Task.Delay(1000);
+                if (tobeSubmitted.TryDequeue(out var usage))
                 {
-                    await Task.Delay(1000);
-                    if (tobeSubmitted.TryDequeue(out var usage))
-                    {
-                        var response = await config.SubmitUsage(usage);
-                        await producer.ReportUsagesSubmitted(response, CancellationToken.None);
-                        _logger.Log(LogLevel.Information, "Submitted {0} values", response.Results.Length);
-                    }
+                    var response = await config.SubmitUsage(usage);
+                    await producer.ReportUsagesSubmitted(response, CancellationToken.None);
+                    _logger.Log(LogLevel.Information, "Submitted {0} values", response.Results.Length);
                 }
-            });
+            }
+        });
 
-            return events
-                .Subscribe(
-                    onNext: meterCollection =>
+        return events
+            .Subscribe(
+                onNext: meterCollection =>
+                {
+                    // Only add new (unseen) events to the concurrent queue.
+                    var current = meterCollection.metersToBeSubmitted().ToList();
+                    var newOnes = current.Except(previousToBeSubmitted).ToList();
+                    if (newOnes.Any())
                     {
-                        // Only add new (unseen) events to the concurrent queue.
-                        var current = meterCollection.metersToBeSubmitted().ToList();
-                        var newOnes = current.Except(previousToBeSubmitted).ToList();
-                        if (newOnes.Any())
-                        {
-                            newOnes
-                                .Chunk(25)
-                                .ForEach(tobeSubmitted.Enqueue);
-                        }
-                        previousToBeSubmitted = current;
+                        newOnes
+                            .Chunk(25)
+                            .ForEach(tobeSubmitted.Enqueue);
                     }
-                );
-        }
-
-        private void RegularlyCreateSnapshots(PartitionID partitionId, MeterCollection meterCollection, Func<string> prefix)
-        {
-            if (meterCollection.getLastSequenceNumber() % 100 == 0)
-            {
-                _logger.LogInformation($"{prefix()} Processed event {partitionId.value()}#{meterCollection.getLastSequenceNumber()}");
-            }
-
-            //if (meterCollection.getLastSequenceNumber() % 500 == 0)
-            {
-                MeterCollectionStore.storeLastState(config, meterCollection: meterCollection).Wait();
-                _logger.LogInformation($"{prefix()} Saved state {partitionId.value()}#{meterCollection.getLastSequenceNumber()}");
-            }
-        }
-
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-        {
-           
-
-            List<IDisposable> subscriptions = new();
-
-            // pretty-print which partitions we already 'own'
-            var props = await config.MeteringConnections.createEventHubConsumerClient().GetEventHubPropertiesAsync(stoppingToken);
-            var partitions = new string[props.PartitionIds.Length];
-            Array.Fill(partitions, "_");
-            string currentPartitions() => string.Join("", partitions);
-
-            var dummy = EventHubObservableClientCSharp.Create(
-                logger: _logger,
-                getPartitionId: EventHubIntegration.partitionId,
-                newEventProcessorClient: config.MeteringConnections.createEventProcessorClient,
-                newEventHubConsumerClient: config.MeteringConnections.createEventHubConsumerClient,
-                eventDataToEvent: CaptureProcessor.toMeteringUpdateEvent,
-                createEventHubEventFromEventData: EventHubIntegration.CreateEventHubEventFromEventData,
-                readAllEvents: config.MeteringConnections.ReadAllEvents,
-                readEventsFromPosition: config.MeteringConnections.ReadEventsFromPosition,
-                loadLastState: config.loadLastState,
-                determinePosition: MeterCollectionLogic.getEventPosition,
-                cancellationToken: stoppingToken);
-
-            var groupedSub = EventHubObservableClient
-                .create<SomeMeterCollection, MeteringUpdateEvent>(
-                    logger: _logger,
-                    getPartitionId: FuncConvert.FromFunc<EventHubProcessorEvent<SomeMeterCollection, MeteringUpdateEvent>, PartitionID>(EventHubIntegration.partitionId),
-                    newEventProcessorClient: FuncConvert.FromFunc(config.MeteringConnections.createEventProcessorClient),
-                    newEventHubConsumerClient: FuncConvert.FromFunc(config.MeteringConnections.createEventHubConsumerClient),
-                    eventDataToEvent: FuncConvert.FromFunc<EventData, MeteringUpdateEvent>(CaptureProcessor.toMeteringUpdateEvent),
-                    createEventHubEventFromEventData: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, ProcessEventArgs, FSharpOption<EventHubEvent<MeteringUpdateEvent>>>(EventHubIntegration.createEventHubEventFromEventData),
-                    readAllEvents: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, PartitionID, CancellationToken, IEnumerable<EventHubEvent<MeteringUpdateEvent>>>((a, b, c) => CaptureProcessor.readAllEvents(a, b, c, config.MeteringConnections)),
-                    readEventsFromPosition: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, MessagePosition, CancellationToken, IEnumerable<EventHubEvent<MeteringUpdateEvent>>>((a, b, c) => CaptureProcessor.readEventsFromPosition(a, b, c, config.MeteringConnections)),
-                    loadLastState: FuncConvert.FromFunc<PartitionID, CancellationToken, Task<SomeMeterCollection>>(config.loadLastState),
-                    determinePosition: FuncConvert.FromFunc<SomeMeterCollection, StartingPosition>(MeterCollectionLogic.getEventPosition),
-                    cancellationToken: stoppingToken)
-                .Subscribe(
-                    onNext: group => {
-                        var partitionId = group.Key;
-                        partitions[int.Parse(partitionId.value())] = partitionId.value();
-
-                        IObservable<MeterCollection> events = group
-                            .Scan(seed: MeterCollectionModule.Uninitialized, accumulator: MeteringAggregator.createAggregator)
-                            .Choose(); // '.Choose()' is cleaner than '.Where(x => x.IsSome()).Select(x => x.Value)'
-
-                        // Subscribe the creation of snapshots
-                        events
-                            .Subscribe(
-                                onNext: coll => RegularlyCreateSnapshots(partitionId, coll, currentPartitions),
-                                onError: ex =>
-                                {
-                                    _logger.LogError($"Error {partitionId.value()}: {ex.Message}");
-                                },
-                                onCompleted: () =>
-                                {
-                                    _logger.LogWarning($"Closing {partitionId.value()}");
-                                    partitions[int.Parse(partitionId.value())] = "_";
-                                })
-                            .AddToSubscriptions(subscriptions);
-
-                        // Subscribe the submission to marketplace.
-                        SubscribeEmitter(events)
-                            .AddToSubscriptions(subscriptions);
-                    },
-                    onCompleted: () => {
-                        _logger.LogWarning($"Closing everything");
-                    }, 
-                    onError: ex => {
-                        _logger.LogCritical($"Error: {ex.Message}");
-                    }
-                );
-            subscriptions.Add(groupedSub);
-
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                await Task.Delay(TimeSpan.FromMinutes(10), stoppingToken);
-            }
-
-            subscriptions.ForEach(subscription => subscription.Dispose());
-        }
+                    previousToBeSubmitted = current;
+                }
+            );
     }
 
-    internal static class E
+    private void RegularlyCreateSnapshots(PartitionID partitionId, MeterCollection meterCollection, Func<string> prefix)
     {
-        public static void AddToSubscriptions(this IDisposable i, List<IDisposable> l) => l.Add(i);
-        public static string UpTo(this string s, int length) => s.Length > length ? s[..length] : s;
-        public static string W(this string s, int width) => String.Format($"{{0,-{width}}}", s);
-        public static void ForEach<T>(this IEnumerable<T> ts, Action<T> action) { foreach (var t in ts) { action(t); } }
+        if (meterCollection.getLastSequenceNumber() % 100 == 0)
+        {
+            _logger.LogInformation($"{prefix()} Processed event {partitionId.value()}#{meterCollection.getLastSequenceNumber()}");
+        }
+
+        //if (meterCollection.getLastSequenceNumber() % 500 == 0)
+        {
+            MeterCollectionStore.storeLastState(config, meterCollection: meterCollection).Wait();
+            _logger.LogInformation($"{prefix()} Saved state {partitionId.value()}#{meterCollection.getLastSequenceNumber()}");
+        }
     }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+       
+
+        List<IDisposable> subscriptions = new();
+
+        // pretty-print which partitions we already 'own'
+        var props = await config.MeteringConnections.createEventHubConsumerClient().GetEventHubPropertiesAsync(stoppingToken);
+        var partitions = new string[props.PartitionIds.Length];
+        Array.Fill(partitions, "_");
+        string currentPartitions() => string.Join("", partitions);
+
+        var dummy = EventHubObservableClientCSharp.Create(
+            logger: _logger,
+            getPartitionId: EventHubIntegration.partitionId,
+            newEventProcessorClient: config.MeteringConnections.createEventProcessorClient,
+            newEventHubConsumerClient: config.MeteringConnections.createEventHubConsumerClient,
+            eventDataToEvent: CaptureProcessor.toMeteringUpdateEvent,
+            createEventHubEventFromEventData: EventHubIntegration.CreateEventHubEventFromEventData,
+            readAllEvents: config.MeteringConnections.ReadAllEvents,
+            readEventsFromPosition: config.MeteringConnections.ReadEventsFromPosition,
+            loadLastState: config.loadLastState,
+            determinePosition: MeterCollectionLogic.getEventPosition,
+            cancellationToken: stoppingToken);
+
+        var groupedSub = EventHubObservableClient
+            .create<SomeMeterCollection, MeteringUpdateEvent>(
+                logger: _logger,
+                getPartitionId: FuncConvert.FromFunc<EventHubProcessorEvent<SomeMeterCollection, MeteringUpdateEvent>, PartitionID>(EventHubIntegration.partitionId),
+                newEventProcessorClient: FuncConvert.FromFunc(config.MeteringConnections.createEventProcessorClient),
+                newEventHubConsumerClient: FuncConvert.FromFunc(config.MeteringConnections.createEventHubConsumerClient),
+                eventDataToEvent: FuncConvert.FromFunc<EventData, MeteringUpdateEvent>(CaptureProcessor.toMeteringUpdateEvent),
+                createEventHubEventFromEventData: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, ProcessEventArgs, FSharpOption<EventHubEvent<MeteringUpdateEvent>>>(EventHubIntegration.createEventHubEventFromEventData),
+                readAllEvents: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, PartitionID, CancellationToken, IEnumerable<EventHubEvent<MeteringUpdateEvent>>>((a, b, c) => CaptureProcessor.readAllEvents(a, b, c, config.MeteringConnections)),
+                readEventsFromPosition: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, MessagePosition, CancellationToken, IEnumerable<EventHubEvent<MeteringUpdateEvent>>>((a, b, c) => CaptureProcessor.readEventsFromPosition(a, b, c, config.MeteringConnections)),
+                loadLastState: FuncConvert.FromFunc<PartitionID, CancellationToken, Task<SomeMeterCollection>>(config.loadLastState),
+                determinePosition: FuncConvert.FromFunc<SomeMeterCollection, StartingPosition>(MeterCollectionLogic.getEventPosition),
+                cancellationToken: stoppingToken)
+            .Subscribe(
+                onNext: group => {
+                    var partitionId = group.Key;
+                    partitions[int.Parse(partitionId.value())] = partitionId.value();
+
+                    IObservable<MeterCollection> events = group
+                        .Scan(seed: MeterCollectionModule.Uninitialized, accumulator: MeteringAggregator.createAggregator)
+                        .Choose(); // '.Choose()' is cleaner than '.Where(x => x.IsSome()).Select(x => x.Value)'
+
+                    // Subscribe the creation of snapshots
+                    events
+                        .Subscribe(
+                            onNext: coll => RegularlyCreateSnapshots(partitionId, coll, currentPartitions),
+                            onError: ex =>
+                            {
+                                _logger.LogError($"Error {partitionId.value()}: {ex.Message}");
+                            },
+                            onCompleted: () =>
+                            {
+                                _logger.LogWarning($"Closing {partitionId.value()}");
+                                partitions[int.Parse(partitionId.value())] = "_";
+                            })
+                        .AddToSubscriptions(subscriptions);
+
+                    // Subscribe the submission to marketplace.
+                    SubscribeEmitter(events)
+                        .AddToSubscriptions(subscriptions);
+                },
+                onCompleted: () => {
+                    _logger.LogWarning($"Closing everything");
+                }, 
+                onError: ex => {
+                    _logger.LogCritical($"Error: {ex.Message}");
+                }
+            );
+        subscriptions.Add(groupedSub);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+            await Task.Delay(TimeSpan.FromMinutes(10), stoppingToken);
+        }
+
+        subscriptions.ForEach(subscription => subscription.Dispose());
+    }
+}
+
+internal static class E
+{
+    public static void AddToSubscriptions(this IDisposable i, List<IDisposable> l) => l.Add(i);
+    public static string UpTo(this string s, int length) => s.Length > length ? s[..length] : s;
+    public static string W(this string s, int width) => String.Format($"{{0,-{width}}}", s);
+    public static void ForEach<T>(this IEnumerable<T> ts, Action<T> action) { foreach (var t in ts) { action(t); } }
 }

--- a/src/AggregatorFunctionHost/AggregatorFunction.cs
+++ b/src/AggregatorFunctionHost/AggregatorFunction.cs
@@ -4,195 +4,194 @@
 // https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection
 [assembly: Microsoft.Azure.Functions.Extensions.DependencyInjection.FunctionsStartup(typeof(AggregatorFunctionHost.AggregatorStartup))]
 
-namespace AggregatorFunctionHost
+namespace AggregatorFunctionHost;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using Microsoft.Azure.WebJobs;   
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Metering.ClientSDK;
+using Metering.BaseTypes;
+using Metering.BaseTypes.EventHub;
+using Metering.Integration;
+using Metering.EventHub;
+using SomeMeterCollection = Microsoft.FSharp.Core.FSharpOption<Metering.BaseTypes.MeterCollection>;
+using Microsoft.FSharp.Core;
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Processor;
+
+public class AggregatorStartup : FunctionsStartup
 {
-    using System;
-    using System.Collections.Concurrent;
-    using System.Collections.Generic;
-    using System.Reactive.Linq;
-    using Microsoft.Azure.WebJobs;   
-    using Microsoft.Azure.Functions.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Logging;
-    using Metering.ClientSDK;
-    using Metering.BaseTypes;
-    using Metering.BaseTypes.EventHub;
-    using Metering.Integration;
-    using Metering.EventHub;
-    using SomeMeterCollection = Microsoft.FSharp.Core.FSharpOption<Metering.BaseTypes.MeterCollection>;
-    using Microsoft.FSharp.Core;
-    using Azure.Messaging.EventHubs;
-    using Azure.Messaging.EventHubs.Processor;
-
-    public class AggregatorStartup : FunctionsStartup
+    public override void Configure(IFunctionsHostBuilder builder)
     {
-        public override void Configure(IFunctionsHostBuilder builder)
+        builder.Services.AddMeteringAggregatorConfigFromEnvironment();
+    }
+}
+
+public class AggregatorFunction
+{
+    private ILogger _logger;
+    private readonly MeteringConfigurationProvider config;
+
+    public AggregatorFunction(MeteringConfigurationProvider mcp)
+    {
+        (config) = (mcp);
+    }
+
+    [FunctionName("AggregatorFunction")]
+    public void Run([TimerTrigger("0 */5 * * * *")]TimerInfo myTimer, ILogger logger, CancellationToken cancellationToken)
+    {
+        this._logger = logger;
+
+        var token = cancellationToken.CancelAfter(TimeSpan.FromMinutes(3)); 
+
+        _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}, Using event hub {config.MeteringConnections.EventHubConfig.EventHubName}");
+        try
         {
-            builder.Services.AddMeteringAggregatorConfigFromEnvironment();
+            ExecuteAsync(token).Wait(token);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Operation cancelled");
         }
     }
 
-    public class AggregatorFunction
+    private IDisposable SubscribeEmitter(IObservable<MeterCollection> events)
     {
-        private ILogger _logger;
-        private readonly MeteringConfigurationProvider config;
+        List<MarketplaceRequest> previousToBeSubmitted = new();
+        ConcurrentQueue<MarketplaceRequest[]> tobeSubmitted = new();
+        var producer = config.MeteringConnections.createEventHubProducerClient();
 
-        public AggregatorFunction(MeteringConfigurationProvider mcp)
-        {
-            (config) = (mcp);
-        }
-
-        [FunctionName("AggregatorFunction")]
-        public void Run([TimerTrigger("0 */5 * * * *")]TimerInfo myTimer, ILogger logger, CancellationToken cancellationToken)
-        {
-            this._logger = logger;
-
-            var token = cancellationToken.CancelAfter(TimeSpan.FromMinutes(3)); 
-
-            _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}, Using event hub {config.MeteringConnections.EventHubConfig.EventHubName}");
-            try
+        // Run an endless loop,
+        // - to look at the concurrent queue,
+        // - submit REST calls to marketplace, and then
+        // - submit the marketplace responses to EventHub. 
+        var task = Task.Factory.StartNew(async () => {
+            while (true)
             {
-                ExecuteAsync(token).Wait(token);
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogInformation("Operation cancelled");
-            }
-        }
-
-        private IDisposable SubscribeEmitter(IObservable<MeterCollection> events)
-        {
-            List<MarketplaceRequest> previousToBeSubmitted = new();
-            ConcurrentQueue<MarketplaceRequest[]> tobeSubmitted = new();
-            var producer = config.MeteringConnections.createEventHubProducerClient();
-
-            // Run an endless loop,
-            // - to look at the concurrent queue,
-            // - submit REST calls to marketplace, and then
-            // - submit the marketplace responses to EventHub. 
-            var task = Task.Factory.StartNew(async () => {
-                while (true)
+                await Task.Delay(1000);
+                if (tobeSubmitted.TryDequeue(out var usage))
                 {
-                    await Task.Delay(1000);
-                    if (tobeSubmitted.TryDequeue(out var usage))
-                    {
-                        var response = await config.SubmitUsage(usage);
-                        await producer.ReportUsagesSubmitted(response, CancellationToken.None);
-                    }
+                    var response = await config.SubmitUsage(usage);
+                    await producer.ReportUsagesSubmitted(response, CancellationToken.None);
                 }
-            });
+            }
+        });
 
-            return events
-                .Subscribe(
-                    onNext: meterCollection =>
+        return events
+            .Subscribe(
+                onNext: meterCollection =>
+                {
+                    // Only add new (unseen) events to the concurrent queue.
+                    var current = meterCollection.metersToBeSubmitted().ToList();
+                    var newOnes = current.Except(previousToBeSubmitted).ToList();
+                    if (newOnes.Any())
                     {
-                        // Only add new (unseen) events to the concurrent queue.
-                        var current = meterCollection.metersToBeSubmitted().ToList();
-                        var newOnes = current.Except(previousToBeSubmitted).ToList();
-                        if (newOnes.Any())
-                        {
-                            newOnes
-                                .Chunk(25)
-                                .ForEach(tobeSubmitted.Enqueue);
-                        }
-                        previousToBeSubmitted = current;
+                        newOnes
+                            .Chunk(25)
+                            .ForEach(tobeSubmitted.Enqueue);
                     }
-                );
-        }
-
-        private void RegularlyCreateSnapshots(PartitionID partitionId, MeterCollection meterCollection, Func<string> prefix)
-        {
-            if (meterCollection.getLastSequenceNumber() % 100 == 0)
-            {
-                _logger.LogInformation($"{prefix()} Processed event {partitionId.value()}#{meterCollection.getLastSequenceNumber()}");
-            }
-
-            if (meterCollection.getLastSequenceNumber() % 500 == 0)
-            {
-                MeterCollectionStore.storeLastState(config, meterCollection: meterCollection).Wait();
-                _logger.LogInformation($"{prefix()} Saved state {partitionId.value()}#{meterCollection.getLastSequenceNumber()}");
-            }
-        }
-
-        private async Task ExecuteAsync(CancellationToken stoppingToken)
-        {
-            List<IDisposable> subscriptions = new();
-
-            // pretty-print which partitions we already 'own'
-            var props = await config.MeteringConnections.createEventHubConsumerClient().GetEventHubPropertiesAsync(stoppingToken);
-            var partitions = new string[props.PartitionIds.Length];
-            Array.Fill(partitions, "_");
-            string currentPartitions() => string.Join("", partitions);
-
-            var groupedSub = EventHubObservableClient
-                .create<SomeMeterCollection, MeteringUpdateEvent>(
-                    logger: _logger,
-                    getPartitionId: FuncConvert.FromFunc<EventHubProcessorEvent<SomeMeterCollection, MeteringUpdateEvent>, PartitionID>(EventHubIntegration.partitionId),
-                    newEventProcessorClient: FuncConvert.FromFunc(config.MeteringConnections.createEventProcessorClient),
-                    newEventHubConsumerClient: FuncConvert.FromFunc(config.MeteringConnections.createEventHubConsumerClient),
-                    eventDataToEvent: FuncConvert.FromFunc<EventData, MeteringUpdateEvent>(CaptureProcessor.toMeteringUpdateEvent),
-                    createEventHubEventFromEventData: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, ProcessEventArgs, FSharpOption<EventHubEvent<MeteringUpdateEvent>>>(EventHubIntegration.createEventHubEventFromEventData),
-                    readAllEvents: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, PartitionID, CancellationToken, IEnumerable<EventHubEvent<MeteringUpdateEvent>>>((a, b, c) => CaptureProcessor.readAllEvents(a, b, c, config.MeteringConnections)),
-                    readEventsFromPosition: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, MessagePosition, CancellationToken, IEnumerable<EventHubEvent<MeteringUpdateEvent>>>((a, b, c) => CaptureProcessor.readEventsFromPosition(a, b, c, config.MeteringConnections)),
-                    loadLastState: FuncConvert.FromFunc<PartitionID, CancellationToken, Task<SomeMeterCollection>>((a, b) => MeterCollectionStore.loadLastState(config, a, b)),
-                    determinePosition: FuncConvert.FromFunc<SomeMeterCollection, StartingPosition>(MeterCollectionLogic.getEventPosition),
-                    cancellationToken: stoppingToken)
-                .Subscribe(
-                    onNext: group => {
-                        var partitionId = group.Key;
-                        partitions[int.Parse(partitionId.value())] = partitionId.value();
-
-                        IObservable<MeterCollection> events = group
-                            .Scan(seed: MeterCollectionModule.Uninitialized, accumulator: MeteringAggregator.createAggregator)
-                            .Choose(); // '.Choose()' is cleaner than '.Where(x => x.IsSome()).Select(x => x.Value)'
-
-                        // Subscribe the creation of snapshots
-                        events
-                            .Subscribe(
-                                onNext: coll => RegularlyCreateSnapshots(partitionId, coll, currentPartitions),
-                                onError: ex =>
-                                {
-                                    _logger.LogError($"Error {partitionId.value()}: {ex.Message}");
-                                },
-                                onCompleted: () =>
-                                {
-                                    _logger.LogWarning($"Closing {partitionId.value()}");
-                                    partitions[int.Parse(partitionId.value())] = "_";
-                                })
-                            .AddToSubscriptions(subscriptions);
-
-                        // Subscribe the submission to marketplace.
-                        SubscribeEmitter(events)
-                            .AddToSubscriptions(subscriptions);
-                    },
-                    onCompleted: () => {
-                        _logger.LogWarning($"Closing everything");
-                    },
-                    onError: ex => {
-                        _logger.LogCritical($"Error: {ex.Message}");
-                    }
-                );
-            subscriptions.Add(groupedSub);
-
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                await Task.Delay(TimeSpan.FromMinutes(10), stoppingToken);
-            }
-
-            subscriptions.ForEach(subscription => subscription.Dispose());
-        }
+                    previousToBeSubmitted = current;
+                }
+            );
     }
 
-    internal static class E
+    private void RegularlyCreateSnapshots(PartitionID partitionId, MeterCollection meterCollection, Func<string> prefix)
     {
-        public static CancellationToken CancelAfter(this CancellationToken token, TimeSpan timeSpan) => 
-            CancellationTokenSource.CreateLinkedTokenSource(
-                token1: token,
-                token2: new CancellationTokenSource(delay: timeSpan).Token).Token;
-        
-        public static void AddToSubscriptions(this IDisposable i, List<IDisposable> l) => l.Add(i);
-        public static string UpTo(this string s, int length) => s.Length > length ? s[..length] : s;
-        public static string W(this string s, int width) => String.Format($"{{0,-{width}}}", s);
-        public static void ForEach<T>(this IEnumerable<T> ts, Action<T> action) { foreach (var t in ts) { action(t); } }
+        if (meterCollection.getLastSequenceNumber() % 100 == 0)
+        {
+            _logger.LogInformation($"{prefix()} Processed event {partitionId.value()}#{meterCollection.getLastSequenceNumber()}");
+        }
+
+        if (meterCollection.getLastSequenceNumber() % 500 == 0)
+        {
+            MeterCollectionStore.storeLastState(config, meterCollection: meterCollection).Wait();
+            _logger.LogInformation($"{prefix()} Saved state {partitionId.value()}#{meterCollection.getLastSequenceNumber()}");
+        }
     }
+
+    private async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        List<IDisposable> subscriptions = new();
+
+        // pretty-print which partitions we already 'own'
+        var props = await config.MeteringConnections.createEventHubConsumerClient().GetEventHubPropertiesAsync(stoppingToken);
+        var partitions = new string[props.PartitionIds.Length];
+        Array.Fill(partitions, "_");
+        string currentPartitions() => string.Join("", partitions);
+
+        var groupedSub = EventHubObservableClient
+            .create<SomeMeterCollection, MeteringUpdateEvent>(
+                logger: _logger,
+                getPartitionId: FuncConvert.FromFunc<EventHubProcessorEvent<SomeMeterCollection, MeteringUpdateEvent>, PartitionID>(EventHubIntegration.partitionId),
+                newEventProcessorClient: FuncConvert.FromFunc(config.MeteringConnections.createEventProcessorClient),
+                newEventHubConsumerClient: FuncConvert.FromFunc(config.MeteringConnections.createEventHubConsumerClient),
+                eventDataToEvent: FuncConvert.FromFunc<EventData, MeteringUpdateEvent>(CaptureProcessor.toMeteringUpdateEvent),
+                createEventHubEventFromEventData: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, ProcessEventArgs, FSharpOption<EventHubEvent<MeteringUpdateEvent>>>(EventHubIntegration.createEventHubEventFromEventData),
+                readAllEvents: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, PartitionID, CancellationToken, IEnumerable<EventHubEvent<MeteringUpdateEvent>>>((a, b, c) => CaptureProcessor.readAllEvents(a, b, c, config.MeteringConnections)),
+                readEventsFromPosition: FuncConvert.FromFunc<FSharpFunc<EventData, MeteringUpdateEvent>, MessagePosition, CancellationToken, IEnumerable<EventHubEvent<MeteringUpdateEvent>>>((a, b, c) => CaptureProcessor.readEventsFromPosition(a, b, c, config.MeteringConnections)),
+                loadLastState: FuncConvert.FromFunc<PartitionID, CancellationToken, Task<SomeMeterCollection>>((a, b) => MeterCollectionStore.loadLastState(config, a, b)),
+                determinePosition: FuncConvert.FromFunc<SomeMeterCollection, StartingPosition>(MeterCollectionLogic.getEventPosition),
+                cancellationToken: stoppingToken)
+            .Subscribe(
+                onNext: group => {
+                    var partitionId = group.Key;
+                    partitions[int.Parse(partitionId.value())] = partitionId.value();
+
+                    IObservable<MeterCollection> events = group
+                        .Scan(seed: MeterCollectionModule.Uninitialized, accumulator: MeteringAggregator.createAggregator)
+                        .Choose(); // '.Choose()' is cleaner than '.Where(x => x.IsSome()).Select(x => x.Value)'
+
+                    // Subscribe the creation of snapshots
+                    events
+                        .Subscribe(
+                            onNext: coll => RegularlyCreateSnapshots(partitionId, coll, currentPartitions),
+                            onError: ex =>
+                            {
+                                _logger.LogError($"Error {partitionId.value()}: {ex.Message}");
+                            },
+                            onCompleted: () =>
+                            {
+                                _logger.LogWarning($"Closing {partitionId.value()}");
+                                partitions[int.Parse(partitionId.value())] = "_";
+                            })
+                        .AddToSubscriptions(subscriptions);
+
+                    // Subscribe the submission to marketplace.
+                    SubscribeEmitter(events)
+                        .AddToSubscriptions(subscriptions);
+                },
+                onCompleted: () => {
+                    _logger.LogWarning($"Closing everything");
+                },
+                onError: ex => {
+                    _logger.LogCritical($"Error: {ex.Message}");
+                }
+            );
+        subscriptions.Add(groupedSub);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+            await Task.Delay(TimeSpan.FromMinutes(10), stoppingToken);
+        }
+
+        subscriptions.ForEach(subscription => subscription.Dispose());
+    }
+}
+
+internal static class E
+{
+    public static CancellationToken CancelAfter(this CancellationToken token, TimeSpan timeSpan) => 
+        CancellationTokenSource.CreateLinkedTokenSource(
+            token1: token,
+            token2: new CancellationTokenSource(delay: timeSpan).Token).Token;
+    
+    public static void AddToSubscriptions(this IDisposable i, List<IDisposable> l) => l.Add(i);
+    public static string UpTo(this string s, int length) => s.Length > length ? s[..length] : s;
+    public static string W(this string s, int width) => String.Format($"{{0,-{width}}}", s);
+    public static void ForEach<T>(this IEnumerable<T> ts, Action<T> action) { foreach (var t in ts) { action(t); } }
 }

--- a/src/Metering.EventHub/EventHubObservableClient.cs
+++ b/src/Metering.EventHub/EventHubObservableClient.cs
@@ -1,147 +1,143 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-namespace Metering.Integration
+namespace Metering.Integration;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Processor;
+using Azure.Messaging.EventHubs.Consumer;
+using Metering.BaseTypes;
+using Metering.BaseTypes.EventHub;
+using Microsoft.FSharp.Core;
+
+public static class EventHubObservableClientCSharp
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using System.Runtime.InteropServices;
-    using System.Reactive.Disposables;
-    using System.Reactive.Linq;
-    using Microsoft.Extensions.Logging;
-    using Azure.Messaging.EventHubs;
-    using Azure.Messaging.EventHubs.Processor;
-    using Azure.Messaging.EventHubs.Consumer;
-    using Metering.BaseTypes;
-    using Metering.BaseTypes.EventHub;
-    using Microsoft.FSharp.Core;
-    using System.Data;
-
-    public static class EventHubObservableClientCSharp
+    private static IObservable<EventHubProcessorEvent<TState, TEvent>> CreateInternal<TState, TEvent>(
+        ILogger logger,
+        Func<PartitionInitializingEventArgs, CancellationToken, Task<TState>> determineInitialState,
+        Func<TState, StartingPosition> determinePositionFromState,
+        Func<EventProcessorClient> newEventProcessorClient,                                                                           // config.MeteringConnections.createEventProcessorClient
+        Func<EventHubConsumerClient> newEventHubConsumerClient,                                                                       // config.MeteringConnections.createEventHubConsumerClient
+        Func<EventData, TEvent> eventDataToEvent,                                                                                     // CaptureProcessor.toMeteringUpdateEvent
+        Func<Func<EventData, TEvent>, ProcessEventArgs, FSharpOption<EventHubEvent<TEvent>>> createEventHubEventFromEventData,        // EventHubIntegration.createEventHubEventFromEventData
+        Func<Func<EventData, TEvent>, PartitionID, CancellationToken, IEnumerable<EventHubEvent<TEvent>>> readAllEvents,              // CaptureProcessor.readAllEvents
+        Func<Func<EventData, TEvent>, MessagePosition, CancellationToken, IEnumerable<EventHubEvent<TEvent>>> readEventsFromPosition, // CaptureProcessor.readEventsFromPosition
+        CancellationToken cancellationToken)
     {
-        private static IObservable<EventHubProcessorEvent<TState, TEvent>> CreateInternal<TState, TEvent>(
-            ILogger logger,
-            Func<PartitionInitializingEventArgs, CancellationToken, Task<TState>> determineInitialState,
-            Func<TState, StartingPosition> determinePositionFromState,
-            Func<EventProcessorClient> newEventProcessorClient,                                                                           // config.MeteringConnections.createEventProcessorClient
-            Func<EventHubConsumerClient> newEventHubConsumerClient,                                                                       // config.MeteringConnections.createEventHubConsumerClient
-            Func<EventData, TEvent> eventDataToEvent,                                                                                     // CaptureProcessor.toMeteringUpdateEvent
-            Func<Func<EventData, TEvent>, ProcessEventArgs, FSharpOption<EventHubEvent<TEvent>>> createEventHubEventFromEventData,        // EventHubIntegration.createEventHubEventFromEventData
-            Func<Func<EventData, TEvent>, PartitionID, CancellationToken, IEnumerable<EventHubEvent<TEvent>>> readAllEvents,              // CaptureProcessor.readAllEvents
-            Func<Func<EventData, TEvent>, MessagePosition, CancellationToken, IEnumerable<EventHubEvent<TEvent>>> readEventsFromPosition, // CaptureProcessor.readEventsFromPosition
-            CancellationToken cancellationToken)
+        void registerCancellationMessage(CancellationToken ct, string message)
         {
-            void registerCancellationMessage(CancellationToken ct, string message)
-            {
-                ct.Register(() => logger.LogWarning(message));
-            }
-
-            registerCancellationMessage(cancellationToken, "outer cancellationToken pulled");
-
-            IDisposable csharpFunction(IObserver<EventHubProcessorEvent<TState, TEvent>> o)
-            {
-                var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                var innerCancellationToken = cts.Token;
-                registerCancellationMessage(innerCancellationToken, "innerCancellationToken is Cancelled");
-
-                Task ProcessEvent(ProcessEventArgs processEventArgs)
-                {
-                    try
-                    {
-                        FSharpOption<EventHubEvent<TEvent>> x = createEventHubEventFromEventData(eventDataToEvent, processEventArgs);
-                        if (x.IsSome())
-                        {
-                            o.OnNext(EventHubProcessorEvent<TState, TEvent>.NewEventHubEvent(x.Value));
-                        }
-                        else
-                        {
-                            LastEnqueuedEventProperties catchUp = processEventArgs.Partition.ReadLastEnqueuedEventProperties();
-                            var msg = $"Didn't find events: PartitionId {processEventArgs.Partition.PartitionId} SequenceNumber {catchUp.SequenceNumber} EnqueuedTime {catchUp.EnqueuedTime} LastReceivedTime {catchUp.LastReceivedTime} ###############";
-                            logger.LogDebug(msg);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex.Message);
-                    }
-                    return Task.CompletedTask;
-                }
-
-                Task ProcessError(ProcessErrorEventArgs processErrorEventArgs)
-                {
-                    try
-                    {
-                        o.OnError(processErrorEventArgs.Exception);
-                    }
-                    catch (Exception e)
-                    {
-                        logger.LogError($"ProcessError Exception {e.Message}");
-                    }
-                    return Task.CompletedTask;
-                }
-
-                Task PartitionClosing(PartitionClosingEventArgs partitionClosingEventArgs)
-                {
-                    try
-                    {
-                        if (partitionClosingEventArgs.CancellationToken.IsCancellationRequested)
-                        {
-                            logger.LogError($"PartitionClosing partitionClosingEventArgs.CancellationToken.IsCancellationRequested");
-                        }
-
-                        if (partitionClosingEventArgs.Reason == ProcessingStoppedReason.OwnershipLost)
-                        {
-                            logger.LogError($"{partitionClosingEventArgs.PartitionId}: ProcessingStoppedReason.OwnershipLost");
-                        }
-                        else
-                        {
-                            logger.LogError($"{partitionClosingEventArgs.PartitionId}: ProcessingStoppedReason.Shutdown");
-                        }
-
-                        o.OnCompleted();
-                    }
-                    catch (Exception e)
-                    {
-                        logger.LogError($"ProcessError Exception {e.Message}");
-                    }
-                    return Task.CompletedTask;
-                }
-
-              throw new NotImplementedException();
-            }
-
-            return Observable.Create<EventHubProcessorEvent<TState, TEvent>>(csharpFunction);   
+            ct.Register(() => logger.LogWarning(message));
         }
 
-        public static IObservable<IGroupedObservable<PartitionID, EventHubProcessorEvent<TState, TEvent>>> Create<TState, TEvent>(
-            ILogger logger,
-            Func<EventHubProcessorEvent<TState, TEvent>, PartitionID> getPartitionId,                                                     // EventHubIntegration.partitionId
-            Func<EventProcessorClient> newEventProcessorClient,                                                                           // config.MeteringConnections.createEventProcessorClient
-            Func<EventHubConsumerClient> newEventHubConsumerClient,                                                                       // config.MeteringConnections.createEventHubConsumerClient
-            Func<EventData, TEvent> eventDataToEvent,                                                                                     // CaptureProcessor.toMeteringUpdateEvent
-            Func<Func<EventData, TEvent>, ProcessEventArgs, FSharpOption<EventHubEvent<TEvent>>> createEventHubEventFromEventData,        // EventHubIntegration.createEventHubEventFromEventData
-            Func<Func<EventData, TEvent>, PartitionID, CancellationToken, IEnumerable<EventHubEvent<TEvent>>> readAllEvents,              // CaptureProcessor.readAllEvents
-            Func<Func<EventData, TEvent>, MessagePosition, CancellationToken, IEnumerable<EventHubEvent<TEvent>>> readEventsFromPosition, // CaptureProcessor.readEventsFromPosition
-            Func<PartitionID, CancellationToken, Task<TState>> loadLastState,                                                             // MeterCollectionStore.loadLastState
-            Func<TState, StartingPosition> determinePosition,                                                                             // MeterCollectionLogic.getEventPosition
-            CancellationToken cancellationToken = default)
+        registerCancellationMessage(cancellationToken, "outer cancellationToken pulled");
+
+        IDisposable csharpFunction(IObserver<EventHubProcessorEvent<TState, TEvent>> o)
         {
-            Task<TState> determineInitialState(PartitionInitializingEventArgs args, CancellationToken ct) => 
-                loadLastState(PartitionIDModule.create(args.PartitionId), ct);
-            
-            return CreateInternal(logger, 
-                    determineInitialState, 
-                    determinePosition,
-                    newEventProcessorClient,
-                    newEventHubConsumerClient,
-                    eventDataToEvent,
-                    createEventHubEventFromEventData,
-                    readAllEvents,
-                    readEventsFromPosition,
-                    cancellationToken)
-                .GroupBy(getPartitionId);
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var innerCancellationToken = cts.Token;
+            registerCancellationMessage(innerCancellationToken, "innerCancellationToken is Cancelled");
+
+            Task ProcessEvent(ProcessEventArgs processEventArgs)
+            {
+                try
+                {
+                    FSharpOption<EventHubEvent<TEvent>> x = createEventHubEventFromEventData(eventDataToEvent, processEventArgs);
+                    if (x.IsSome())
+                    {
+                        o.OnNext(EventHubProcessorEvent<TState, TEvent>.NewEventHubEvent(x.Value));
+                    }
+                    else
+                    {
+                        LastEnqueuedEventProperties catchUp = processEventArgs.Partition.ReadLastEnqueuedEventProperties();
+                        var msg = $"Didn't find events: PartitionId {processEventArgs.Partition.PartitionId} SequenceNumber {catchUp.SequenceNumber} EnqueuedTime {catchUp.EnqueuedTime} LastReceivedTime {catchUp.LastReceivedTime} ###############";
+                        logger.LogDebug(msg);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex.Message);
+                }
+                return Task.CompletedTask;
+            }
+
+            Task ProcessError(ProcessErrorEventArgs processErrorEventArgs)
+            {
+                try
+                {
+                    o.OnError(processErrorEventArgs.Exception);
+                }
+                catch (Exception e)
+                {
+                    logger.LogError($"ProcessError Exception {e.Message}");
+                }
+                return Task.CompletedTask;
+            }
+
+            Task PartitionClosing(PartitionClosingEventArgs partitionClosingEventArgs)
+            {
+                try
+                {
+                    if (partitionClosingEventArgs.CancellationToken.IsCancellationRequested)
+                    {
+                        logger.LogError($"PartitionClosing partitionClosingEventArgs.CancellationToken.IsCancellationRequested");
+                    }
+
+                    if (partitionClosingEventArgs.Reason == ProcessingStoppedReason.OwnershipLost)
+                    {
+                        logger.LogError($"{partitionClosingEventArgs.PartitionId}: ProcessingStoppedReason.OwnershipLost");
+                    }
+                    else
+                    {
+                        logger.LogError($"{partitionClosingEventArgs.PartitionId}: ProcessingStoppedReason.Shutdown");
+                    }
+
+                    o.OnCompleted();
+                }
+                catch (Exception e)
+                {
+                    logger.LogError($"ProcessError Exception {e.Message}");
+                }
+                return Task.CompletedTask;
+            }
+
+          throw new NotImplementedException();
         }
+
+        return Observable.Create<EventHubProcessorEvent<TState, TEvent>>(csharpFunction);   
+    }
+
+    public static IObservable<IGroupedObservable<PartitionID, EventHubProcessorEvent<TState, TEvent>>> Create<TState, TEvent>(
+        ILogger logger,
+        Func<EventHubProcessorEvent<TState, TEvent>, PartitionID> getPartitionId,                                                     // EventHubIntegration.partitionId
+        Func<EventProcessorClient> newEventProcessorClient,                                                                           // config.MeteringConnections.createEventProcessorClient
+        Func<EventHubConsumerClient> newEventHubConsumerClient,                                                                       // config.MeteringConnections.createEventHubConsumerClient
+        Func<EventData, TEvent> eventDataToEvent,                                                                                     // CaptureProcessor.toMeteringUpdateEvent
+        Func<Func<EventData, TEvent>, ProcessEventArgs, FSharpOption<EventHubEvent<TEvent>>> createEventHubEventFromEventData,        // EventHubIntegration.createEventHubEventFromEventData
+        Func<Func<EventData, TEvent>, PartitionID, CancellationToken, IEnumerable<EventHubEvent<TEvent>>> readAllEvents,              // CaptureProcessor.readAllEvents
+        Func<Func<EventData, TEvent>, MessagePosition, CancellationToken, IEnumerable<EventHubEvent<TEvent>>> readEventsFromPosition, // CaptureProcessor.readEventsFromPosition
+        Func<PartitionID, CancellationToken, Task<TState>> loadLastState,                                                             // MeterCollectionStore.loadLastState
+        Func<TState, StartingPosition> determinePosition,                                                                             // MeterCollectionLogic.getEventPosition
+        CancellationToken cancellationToken = default)
+    {
+        Task<TState> determineInitialState(PartitionInitializingEventArgs args, CancellationToken ct) => 
+            loadLastState(PartitionIDModule.create(args.PartitionId), ct);
+        
+        return CreateInternal(logger, 
+                determineInitialState, 
+                determinePosition,
+                newEventProcessorClient,
+                newEventHubConsumerClient,
+                eventDataToEvent,
+                createEventHubEventFromEventData,
+                readAllEvents,
+                readEventsFromPosition,
+                cancellationToken)
+            .GroupBy(getPartitionId);
     }
 }


### PR DESCRIPTION
through the new `namespace foo;` declaration, instead of the traditional `namespace foo {}` construct.

Going from 

```csharp
namespace foo
{
   class blah{}
}
```

to

```csharp
namespace foo;

class blah{}
```
