### PR TITLE
fix the failing builds

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 6.0.300
     - name: Restore dependencies
       working-directory: ./src
       run: dotnet restore

--- a/src/Demos/DemoWebApp/Dockerfile
+++ b/src/Demos/DemoWebApp/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0.300 AS build
 WORKDIR /src
 COPY ["Demos/DemoWebApp/DemoWebApp.csproj", "Demos/DemoWebApp/"]
 COPY ["Metering.BaseTypes/Metering.BaseTypes.fsproj", "Metering.BaseTypes/"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0.300 AS build
 WORKDIR /src
 COPY ["Aggregator/Aggregator.csproj", "Aggregator/"]
 RUN dotnet restore "Aggregator/Aggregator.csproj"


### PR DESCRIPTION
This add a patch version to the dotnet sdk to ensure that correct sdk semantic version is installed when running the build. Automatically github action picks up the latest skd which is using the version 6.0 and this resolves to 6.0.4. These changes ensure that the runs can be set to specific sdk semantic version until the a new version is tested and the files included in this PR are updated as well.