### PR TITLE
Fix for handling TaskCanceledException in EventHubObservableClient

### DIFF
--- a/src/Metering.EventHub/EventHubObservableClient.cs
+++ b/src/Metering.EventHub/EventHubObservableClient.cs
@@ -332,11 +332,11 @@ public static class EventHubObservableClient
                     catch (Exception ex) { o.OnError(ex); }
                     finally{
                         try
-				        {
-							o.OnCompleted();
-							processor.StopProcessing();
-						}
-						catch (Exception) { }
+			{
+				o.OnCompleted();
+				processor.StopProcessing();
+			}
+			catch (Exception) { }
                     }
                 }
                 finally

--- a/src/Metering.EventHub/EventHubObservableClient.cs
+++ b/src/Metering.EventHub/EventHubObservableClient.cs
@@ -326,15 +326,18 @@ public static class EventHubObservableClient
                     {
                         await processor.StartProcessingAsync(cancellationToken);
                         logger.LogInformation($"createTask / processor.StartProcessingAsync called");
-                        try{
-                            await Task.Delay(Timeout.Infinite, cancellationToken);
-                        }
-                        catch (TaskCanceledException) { }
-                        o.OnCompleted();
-                        await processor.StopProcessingAsync(cancellationToken);
+                        await Task.Delay(Timeout.Infinite, cancellationToken);
                     }
                     catch (TaskCanceledException) { }
                     catch (Exception ex) { o.OnError(ex); }
+                    finally{
+                        try
+				        {
+							o.OnCompleted();
+							processor.StopProcessing();
+						}
+						catch (Exception) { }
+                    }
                 }
                 finally
                 {

--- a/src/Metering.EventHub/EventHubObservableClient.cs
+++ b/src/Metering.EventHub/EventHubObservableClient.cs
@@ -326,14 +326,17 @@ public static class EventHubObservableClient
                     {
                         await processor.StartProcessingAsync(cancellationToken);
                         logger.LogInformation($"createTask / processor.StartProcessingAsync called");
-                        await Task.Delay(Timeout.Infinite, cancellationToken);
+                        try{
+                            await Task.Delay(Timeout.Infinite, cancellationToken);
+                        }
+                        catch (TaskCanceledException) { }
                         o.OnCompleted();
                         await processor.StopProcessingAsync(cancellationToken);
                     }
                     catch (TaskCanceledException) { }
                     catch (Exception ex) { o.OnError(ex); }
                 }
-                catch (Exception)
+                finally
                 {
                     processor.ProcessEventAsync -= ProcessEvent;
                     processor.ProcessErrorAsync -= ProcessError;


### PR DESCRIPTION
This fixes handling of TaskCanceledException exception in EventHubObservableClient. Also improved cleanup of the event subscriptions to be executed every time instead of just when an exception has occurred.
Without separately catching the TaskCanceledException from Task.Delay, the EventProcessorClient.StopProcessing was never actually executed. This left an instance of EventProcessorClient to memory in running state.