### PR TITLE
Update WaterfallBilling static member to resolve Docker image build

### DIFF
--- a/src/Metering.BaseTypes/WaterfallBilling.fs
+++ b/src/Metering.BaseTypes/WaterfallBilling.fs
@@ -30,7 +30,7 @@ type WaterfallMeterValue =
   { Total: Quantity
     Consumption: WaterfallConsumption
     LastUpdate: MeteringDateTime }
-  with static EmptyConsumption : WaterfallConsumption = Map.empty<DimensionId, Quantity>
+  with static member EmptyConsumption : WaterfallConsumption = Map.empty<DimensionId, Quantity>
 
 /// These must be reported
 type ConsumptionReport =


### PR DESCRIPTION
This change resolves the issues with the Docker image build:

```
/src/Metering.BaseTypes/WaterfallBilling.fs(33,8): error FS3862: Incomplete declaration of a static construct. Use 'static let','static do','static member' or 'static val' for declaration. [/src/Metering.BaseTypes/Metering.BaseTypes.fsproj]
```